### PR TITLE
Add `external_package_names(topology)`

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -2,7 +2,7 @@ name = "PlutoDependencyExplorer"
 uuid = "72656b73-756c-7461-726b-72656b6b696b"
 license = "MIT"
 authors = ["Paul Berg <paul@plutojl.org>", "Fons van der Plas <fons@plutojl.org>"]
-version = "1.1.0"
+version = "1.2.0"
 
 [deps]
 ExpressionExplorer = "21656369-7473-754a-2065-74616d696c43"

--- a/src/PlutoDependencyExplorer.jl
+++ b/src/PlutoDependencyExplorer.jl
@@ -18,9 +18,10 @@ abstract type AbstractCell end
 include("./data structures.jl")
 include("./ExpressionExplorer.jl")
 include("./Topology.jl")
+include("./imports.jl")
 include("./Errors.jl")
 include("./TopologicalOrder.jl")
 include("./topological_order.jl")
 include("./TopologyUpdate.jl")
 
-end
+end 

--- a/src/imports.jl
+++ b/src/imports.jl
@@ -1,0 +1,12 @@
+import ExpressionExplorer
+
+"""
+```julia
+external_package_names(topology::NotebookTopology)::Set{Symbol}
+```
+
+Get the set of package names that are imported by any cell in the notebook. This considers all `using` and `import` calls.
+"""
+function ExpressionExplorer.external_package_names(topology::NotebookTopology)::Set{Symbol}
+    union!(Set{Symbol}(), ExpressionExplorer.external_package_names.(c.module_usings_imports for c in values(topology.codes))...)
+end

--- a/test/imports.jl
+++ b/test/imports.jl
@@ -1,0 +1,30 @@
+using Test
+import PlutoDependencyExplorer as PDE
+import PlutoDependencyExplorer.ExpressionExplorer
+
+@testset "external_package_names" begin
+    struct SimpleCell <: PDE.AbstractCell
+        code
+    end
+
+    notebook = SimpleCell.([
+        "using Plots, Example.Something"
+        """begin
+            import .Yoooo
+            import Sick: nice
+        end"""
+        ":(import Nonono)"
+    ]);
+
+    empty_topology = PDE.NotebookTopology{SimpleCell}();
+
+    topology = PDE.updated_topology(
+        empty_topology,
+        notebook, notebook;
+        get_code_str = c -> c.code,
+        get_code_expr = c -> Meta.parse(c.code),
+    );
+    
+    @test ExpressionExplorer.external_package_names(topology) == Set([:Plots, :Example, :Sick])
+        
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -3,5 +3,6 @@ using PlutoDependencyExplorer
 
 
 include("./basic.jl")
+include("./imports.jl")
 include("./data structures.jl")
 include("./pluto integration/run.jl")


### PR DESCRIPTION
This adds a new method:

```julia
ExpressionExplorer.external_package_names(topology::PlutoDependencyExplorer.NotebookTopology)::Set{Symbol}
```

Get the set of package names that are imported by any cell in the notebook. This considers all `using` and `import` calls.


Used to be defined in Pluto