### PR TITLE
Reference macro arguments

### DIFF
--- a/src/ExpressionExplorer.jl
+++ b/src/ExpressionExplorer.jl
@@ -11,7 +11,7 @@ module Fake
     module PlutoRunner
         using Markdown
         using InteractiveUtils
-        macro bind(def, element)    
+        macro bind(def, element)
             quote
                 global $(esc(def)) = element
             end
@@ -41,7 +41,7 @@ function pretransform_pluto(ex)
                 try
                     arg_transformed = pretransform_pluto(arg)
                     macro_arg_symstate = ExpressionExplorer.compute_symbols_state(arg_transformed)
-                    
+
                     # When this macro has something special inside like `Pkg.activate()`, we're going to make sure that ExpressionExplorer treats it as normal code, not inside a macrocall. (so these heuristics trigger later)
                     if arg isa Expr && macro_has_special_heuristic_inside(symstate = macro_arg_symstate, expr = arg_transformed)
                         # then the whole argument expression should be added
@@ -62,11 +62,11 @@ function pretransform_pluto(ex)
                     @debug "Error in pretransform_pluto" ex exception=(e, catch_backtrace())
                 end
             end
-            
+
             Expr(
                 :block,
                 # the original expression, not expanded. ExpressionExplorer will just explore the name of the macro, and nothing else.
-                ex, 
+                ex,
                 # any expressions that we need to sneakily add
                 to_add...
             )
@@ -74,7 +74,7 @@ function pretransform_pluto(ex)
             Expr(
                 :block,
                 # We were able to expand the macro, so let's recurse on the result.
-                pretransform_pluto(maybe_expanded), 
+                pretransform_pluto(maybe_expanded),
                 # the name of the macro that got expanded
                 Expr(:macrocall, ex.args[1]),
             )

--- a/src/ExpressionExplorer.jl
+++ b/src/ExpressionExplorer.jl
@@ -33,10 +33,9 @@ In those cases, we want most accurate result possible. Our extra needs are:
 """
 function pretransform_pluto(ex)
     if Meta.isexpr(ex, :macrocall)
-        to_add = Expr[]
-        
         maybe_expanded = maybe_macroexpand_pluto(ex)
         if maybe_expanded === ex
+            to_add = Union{Symbol, Expr}[]
             # we were not able to expand statically
             for arg in ex.args[begin+1:end]
                 try
@@ -53,6 +52,11 @@ function pretransform_pluto(ex)
                             # fn is a FunctionName
                             # normally this would not be a legal expression, but ExpressionExplorer handles it correctly so it's all cool
                         end
+                        # Also surface variable references from macro arguments.
+                        # This allows Pluto to detect dependencies like `UInt2` in `@enumx Turn::UInt2`,
+                        # or `myvar` in `@b myfunction(myvar)`, even when the macro can't be expanded yet.
+                        # We only add references (not definitions/assignments) to avoid false conflicts.
+                        append!(to_add, macro_arg_symstate.references)
                     end
                 catch e
                     @debug "Error in pretransform_pluto" ex exception=(e, catch_backtrace())

--- a/test/basic.jl
+++ b/test/basic.jl
@@ -43,3 +43,30 @@ import PlutoDependencyExplorer as PDE
 
     @test order.runnable == notebook[[2, 1]]
 end
+
+@testset "Macro argument references" begin
+    struct SimpleCell3 <: PDE.AbstractCell
+        code
+    end
+
+    # Cell 1 uses an unknown macro with an expression referencing `bar`, cell 2 defines `bar`.
+    # pretransform_pluto should surface `bar` as a reference from cell 1,
+    # creating a dependency edge: cell 2 must run before cell 1 despite notebook order.
+    notebook = SimpleCell3.([
+        "@unknown_macro(1 + bar)"
+        "bar = 42"
+    ]);
+
+    empty_topology = PDE.NotebookTopology{SimpleCell3}();
+
+    topology = PDE.updated_topology(
+        empty_topology,
+        notebook, notebook;
+        get_code_str = c -> c.code,
+        get_code_expr = c -> Meta.parse(c.code),
+    );
+
+    order = PDE.topological_order(topology);
+
+    @test order.runnable == notebook[[2, 1]]
+end


### PR DESCRIPTION
When a macro call cannot be expanded statically, pretransform_pluto now
surfaces variable references from the macro's arguments. This allows
Pluto to detect dependencies like `bar` in `@unknown_macro(1 + bar)`
even before the macro is expanded, creating correct dependency edges in
the topology.

Changes:
- Move `to_add` inside the non-expandable branch and type it as
  `Union{Symbol, Expr}[]` for type stability
- Append `macro_arg_symstate.references` (symbols) to `to_add` alongside
  the existing macrocall expressions
- Add test case verifying that a macro argument reference creates a
  dependency edge in topological ordering

This change was necessary to get a document, which worked on Pluto with Julia 1.11, to work correctly with Pluto on Julia 1.12, too.

I used Claude Opus 4.6 for the analysis and to come up with an initial version of the change and refactored it afterwards.

I recommend to review the two commits separately. I can remove the whitespace changes in the second commit if they are not welcomed.